### PR TITLE
Add drives context drawer

### DIFF
--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -16,6 +16,7 @@ desktop-view-options = Desktop view options...
 show-on-desktop = Show on Desktop
 desktop-folder-content = Desktop folder content
 mounted-drives = Mounted drives
+no-mounted-drives = No drives mounted yet
 trash-folder-icon = Trash folder icon
 icon-size-and-spacing = Icon size and spacing
 icon-size = Icon size


### PR DESCRIPTION
## Summary
- add a dedicated Drives context drawer below Networks that lists mounted volumes with open and eject actions
- remove the mounted drive section from the Network drawer so it focuses on connection guidance
- add an English string for the empty state when no drives are mounted

## Testing
- cargo fmt
- cargo test *(fails: system library `xkbcommon` required by `smithay-client-toolkit` is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ab5560048327b5aaa19dbb67dd43