### PR TITLE
Add context menu option to open directories as root

### DIFF
--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -307,6 +307,7 @@ extract-here = Extract
 new-file = New file...
 new-folder = New folder...
 open-in-terminal = Open in terminal
+open-as-root = Open as root
 move-to-trash = Move to trash
 restore-from-trash = Restore from trash
 remove-from-sidebar = Remove from sidebar

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -186,6 +186,7 @@ pub fn context_menu<'a>(
                     if selected_dir == 1 {
                         children
                             .push(menu_item(fl!("open-in-terminal"), Action::OpenTerminal).into());
+                        children.push(menu_item(fl!("open-as-root"), Action::OpenAsRoot).into());
                     }
                 }
                 if matches!(tab.location, Location::Search(..) | Location::Recents) {


### PR DESCRIPTION
## Summary
- add an `Open as root` action and wire it into the directory context menu
- launch COSMIC Files via `pkexec` so a password prompt appears before opening the directory as root
- localize the new menu label in English resources

## Testing
- cargo fmt
- cargo check *(fails: blocked waiting for cargo fetch to finish; command cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b662dd7c83278ea6bac7c54ca21c