### PR TITLE
Add Open as Root context menu action

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,7 +753,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.111",
- "which",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -1564,6 +1564,7 @@ dependencies = [
  "uzers",
  "walkdir",
  "wayland-client",
+ "which 7.0.3",
  "xdg",
  "xdg-mime",
  "zip",
@@ -2167,6 +2168,12 @@ dependencies = [
  "log",
  "regex",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "env_logger"
@@ -8223,6 +8230,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix 1.1.3",
+ "winsafe",
+]
+
+[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8912,6 +8931,12 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ trash = { git = "https://github.com/jackpot51/trash-rs.git", branch = "cosmic" }
 url = "2.5"
 walkdir = "2.5.0"
 wayland-client = { version = "0.31.11", optional = true }
+which = "7.0.0"
 xdg = { version = "3.0", optional = true }
 xdg-mime = { git = "https://github.com/ebassi/xdg-mime-rs" }
 # Compression

--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -306,6 +306,7 @@ eject = Eject
 extract-here = Extract
 new-file = New file...
 new-folder = New folder...
+open-as-root = Open as root
 open-in-terminal = Open in terminal
 move-to-trash = Move to trash
 restore-from-trash = Restore from trash

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -19,7 +19,7 @@ use mime_guess::Mime;
 use std::{collections::HashMap, sync::LazyLock};
 
 use crate::{
-    app::{Action, Message},
+    app::{self, Action, Message},
     config::Config,
     fl,
     tab::{self, HeadingOptions, Location, LocationMenuAction, Tab},
@@ -185,6 +185,9 @@ pub fn context_menu<'a>(
                 }
                 if selected == 1 {
                     children.push(menu_item(fl!("menu-open-with"), Action::OpenWith).into());
+                    if selected_dir == 1 && app::elevation_supported() {
+                        children.push(menu_item(fl!("open-as-root"), Action::OpenAsRoot).into());
+                    }
                     if selected_dir == 1 {
                         children
                             .push(menu_item(fl!("open-in-terminal"), Action::OpenTerminal).into());

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1611,6 +1611,7 @@ pub enum Command {
     ExecEntryAction(cosmic::desktop::DesktopEntryData, usize),
     Iced(TaskWrapper),
     OpenFile(Vec<PathBuf>),
+    OpenAsRoot(PathBuf),
     OpenInNewTab(PathBuf),
     OpenInNewWindow(PathBuf),
     OpenTrash,
@@ -1659,6 +1660,7 @@ pub enum Message {
     Location(Location),
     LocationUp,
     Open(Option<PathBuf>),
+    OpenAsRoot,
     Reload,
     RightClick(Option<Point>, Option<usize>),
     MiddleClick(usize),
@@ -3809,6 +3811,19 @@ impl Tab {
 
                             commands.push(Command::OpenFile(open_files));
                         }
+                    }
+                }
+            }
+            Message::OpenAsRoot => {
+                if let Some(items) = self.items_opt.as_ref() {
+                    if let Some(path) = items
+                        .iter()
+                        .find(|item| item.selected && item.metadata.is_dir())
+                        .and_then(|item| item.location_opt.as_ref())
+                        .and_then(Location::path_opt)
+                        .cloned()
+                    {
+                        commands.push(Command::OpenAsRoot(path));
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add an Open as Root context menu option for single directories when elevation is available
- wire a new action through tabs/app logic to spawn the file manager via pkexec
- update localization strings for the new menu entry

## Testing
- cargo fmt
- cargo check *(fails: missing system dependency `xkbcommon` via pkg-config)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69592f3b8aa48327a95e018b8832265f)